### PR TITLE
Allow values to be written as chars

### DIFF
--- a/src/Syntax/AST.hs
+++ b/src/Syntax/AST.hs
@@ -69,6 +69,7 @@ data Stmt
 
 data Expr
   = EInt Int -- NOTE: an integer may not (yet) be negative.
+  | EChar Char -- NOTE: chars should be convertable to integers and should thus not be larger than 255
   deriving (Show)
 
 type Ident = String

--- a/src/Syntax/AST.hs
+++ b/src/Syntax/AST.hs
@@ -22,6 +22,7 @@ module Syntax.AST
 --   SSub    ::= "sub" Ident Expr
 --   Expr    ::= EInt
 --   EInt    ::= (digit)+
+--   EChar   ::= "'" satisfy isAscii "'"
 --   Block   ::= "{" Program "}"
 --   Ident   ::= (lowercase | uppercase)(lowercase | uppercase | digit)*
 

--- a/src/Syntax/Parser.hs
+++ b/src/Syntax/Parser.hs
@@ -149,10 +149,15 @@ stmtSub =
      return SSub { _name = name, _value = value }
 
 expr :: Parser Char Maybe Expr
-expr = exprInt
+expr = exprInt <|> exprChar
 
 exprInt :: Parser Char Maybe Expr
 exprInt = EInt <$> int
+
+exprChar :: Parser Char Maybe Expr
+exprChar = between (symbol '\'') (symbol '\'') f
+    where
+      f = EChar <$> satisfy isAscii
 
 block :: Parser Char Maybe [Stmt]
 block =

--- a/src/Target/Compiler.hs
+++ b/src/Target/Compiler.hs
@@ -141,13 +141,19 @@ compile SClear { _name = name } c
 -- Add a value to a cell.
 compile SAdd { _name = name, _value = value } c
   = case value of
-      EInt value -> compilerGoToSymbol name c
-                >>= return . over output (++ (take value $ repeat BFIncrement))
+      EInt value -> fAdd name value c
+      EChar char -> fAdd name (ord char) c
+    where
+      fAdd name value c = compilerGoToSymbol name c
+              >>= return . over output (++ (take value $ repeat BFIncrement))
 -- Subtract a value from a cell.
 compile SSub { _name = name, _value = value } c
   = case value of
-      EInt value -> compilerGoToSymbol name c
-                >>= return . over output (++ (take value $ repeat BFDecrement))
+      EInt value -> fSub name value c
+      EChar char -> fSub name (ord char) c
+    where
+      fSub name value c = compilerGoToSymbol name c
+                      >>= return . over output (++ (take value $ repeat BFDecrement))
 -- Compile an expression.
 compileExpr :: Expr -> Compiler -> Either String Compiler
 compileExpr (EInt value)

--- a/src/Target/Compiler.hs
+++ b/src/Target/Compiler.hs
@@ -152,6 +152,8 @@ compile SSub { _name = name, _value = value } c
 compileExpr :: Expr -> Compiler -> Either String Compiler
 compileExpr (EInt value)
   = Right . over output (++ (take value $ repeat BFIncrement))
+compileExpr (EChar c)
+  = let value = ord c in Right . over output (++ (take value $ repeat BFIncrement))
 
 -- Move the compiler to a symbol.
 compilerGoToSymbol :: Ident -> Compiler -> Either String Compiler


### PR DESCRIPTION
This PR allows you to do
```
var x 'A';
```
instead of
```
var x 65;
```
This makes code working with characters much, much more readable.

Note that this is a very simple implementation and escape characters like \n don't work.